### PR TITLE
Add g++ dep to dockerfile

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ WORKDIR /app
 ENV CONDA_ROOT /var/lib/conda
 
 RUN apt-get update && \
-    apt-get install --yes bzip2 coreutils curl libc6 libc6-dev libc-dev gcc net-tools && \
+    apt-get install --yes bzip2 coreutils curl libc6 libc6-dev libc-dev gcc g++ net-tools && \
     apt-get autoclean
 
 RUN curl https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh > miniconda.sh


### PR DESCRIPTION
I’m trying to change the pinned SHAP pkg version from `0.40.0` -> `0.35.0` because SHAP `0.40.0` requires sklearn `0.20.0`. Adroit is at sklearn `0.19.1` . SHAP `0.35.0` is the latest version that appears to use an older version of sklearn.
When trying to update lockfiles with `shap==0.35.0`  I get
 ` gcc: error trying to exec 'cc1plus': execvp: No such file or directory`
  `error: command 'gcc' failed with exit status 1`
  
  [The common solutions](https://stackoverflow.com/questions/8878676/compile-error-g-error-trying-to-exec-cc1plus-execvp-no-such-file-or-dir/22072238) indicate missing gcc / g++ packages

I was able to generate the Darwin lock, but not the Linux lock. This PR adds the `g++` dep to the container that builds the linux lockfile