### PR TITLE
Debug build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: rust
 sudo: required
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,7 +4,7 @@ set -e
 
 if [[ "$(uname)" == "Darwin" ]]; then
     URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-MacOSX-x86_64.sh"
-    ln -s $HOME/miniconda/libffi.7.dylib $HOME/miniconda/libffi.6.dylib
+    ln -s $HOME/miniconda/lib/libffi.7.dylib $HOME/miniconda/lib/libffi.6.dylib
 else
     URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh"
 fi

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,10 +4,10 @@ set -e
 
 if [[ "$(uname)" == "Darwin" ]]; then
     URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-MacOSX-x86_64.sh"
+    ln -s $HOME/miniconda/libffi.7.dylib $HOME/miniconda/libffi.6.dylib
 else
     URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh"
 fi
-ln -s libffi.7.dylib libffi.6.dylib
 wget $URL -O miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -17,6 +17,7 @@ ls $HOME/miniconda/lib/
 echo "here2"
 conda update -q conda
 ls $HOME/miniconda/lib/
+ln -s $HOME/miniconda/lib/libffi.7.dylib $HOME/miniconda/lib/libffi.6.dylib
 echo "here3"
 # Useful for debugging any issues with conda
 conda info -a

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,12 +4,13 @@ set -e
 
 if [[ "$(uname)" == "Darwin" ]]; then
     URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-MacOSX-x86_64.sh"
+    brew install libffi
 else
     URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh"
 fi
 wget $URL -O miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda
-ln -s $HOME/miniconda/lib/libffi.7.dylib $HOME/miniconda/lib/libffi.6.dylib
+ls $HOME/miniconda/lib/
 export PATH="$HOME/miniconda/bin:$PATH"
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,7 +4,6 @@ set -e
 
 if [[ "$(uname)" == "Darwin" ]]; then
     URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-MacOSX-x86_64.sh"
-    brew install libffi
 else
     URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh"
 fi

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,12 +4,12 @@ set -e
 
 if [[ "$(uname)" == "Darwin" ]]; then
     URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-MacOSX-x86_64.sh"
-    ln -s $HOME/miniconda/lib/libffi.7.dylib $HOME/miniconda/lib/libffi.6.dylib
 else
     URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh"
 fi
 wget $URL -O miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda
+ln -s $HOME/miniconda/lib/libffi.7.dylib $HOME/miniconda/lib/libffi.6.dylib
 export PATH="$HOME/miniconda/bin:$PATH"
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -7,6 +7,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
 else
     URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh"
 fi
+ln -s libffi.7.dylib libffi.6.dylib
 wget $URL -O miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -11,9 +11,16 @@ wget $URL -O miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda
 ls $HOME/miniconda/lib/
 export PATH="$HOME/miniconda/bin:$PATH"
+echo "here1"
 conda config --set always_yes yes --set changeps1 no
+ls $HOME/miniconda/lib/
+echo "here2"
 conda update -q conda
+ls $HOME/miniconda/lib/
+echo "here3"
 # Useful for debugging any issues with conda
 conda info -a
-
+ls $HOME/miniconda/lib/
+echo "here4"
 conda install -q conda-build anaconda-client
+ls $HOME/miniconda/lib/

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -9,19 +9,15 @@ else
 fi
 wget $URL -O miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda
-ls $HOME/miniconda/lib/
 export PATH="$HOME/miniconda/bin:$PATH"
-echo "here1"
 conda config --set always_yes yes --set changeps1 no
-ls $HOME/miniconda/lib/
-echo "here2"
 conda update -q conda
-ls $HOME/miniconda/lib/
+
+# `conda update -q conda` removes libffi.6.dylib and replaces it with libffi.7.dylib and libffi.8.dylib
+# libffi.6.dylib is required for `conda install`. https://github.com/conda/conda/issues/9038.
 ln -s $HOME/miniconda/lib/libffi.7.dylib $HOME/miniconda/lib/libffi.6.dylib
-echo "here3"
+
 # Useful for debugging any issues with conda
 conda info -a
-ls $HOME/miniconda/lib/
-echo "here4"
+
 conda install -q conda-build anaconda-client
-ls $HOME/miniconda/lib/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-lockfile
-  version: "0.7"
+  version: "0.8"
 
 channels:
 - conda-forge


### PR DESCRIPTION
`conda update -q conda` removes libffi.6.dylib and replaces it with libffi.7.dylib and libffi.8.dylib
libffi.6.dylib is required for `conda install`. https://github.com/conda/conda/issues/9038.