### PR TITLE
Update config.yml deploy workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,16 +45,12 @@ workflows:
       - unit_test_linux
       - unit_test_darwin
       - deploy_linux:
-          requires:
-            - unit_test_linux
           filters:
             tags:
               only: /release_.*/
             branches:
               ignore: /.*/
       - deploy_darwin:
-          requires:
-            - unit_test_darwin
           filters:
             tags:
               only: /release_.*/


### PR DESCRIPTION
Remove `requires:` jobs.

When cutting a release `unit_test_linux` and `unit_test_darwin` should already have ran on merge to main. Those jobs are not rerun on a deploy, and I suspect this is preventing `deploy_linux` and `deploy_darwin` from running