### PR TITLE
debug ssh and flaky builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,14 @@ jobs:
 workflows:
   run_ci:
     jobs:
-      - unit_test_linux
-      - unit_test_darwin
+      - unit_test_linux:
+          filters:
+            tags:
+              only: /release_.*/
+      - unit_test_darwin:
+          filters:
+            tags:
+              only: /release_.*/
       - deploy_linux:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,16 @@ workflows:
             tags:
               only: /release_.*/
       - deploy_linux:
+          requires:
+            - unit_test_linux
           filters:
             tags:
               only: /release_.*/
             branches:
               ignore: /.*/
       - deploy_darwin:
+          requires:
+            - unit_test_darwin
           filters:
             tags:
               only: /release_.*/

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -3,10 +3,10 @@
 set -e
 
 export PATH="$HOME/miniconda/bin:$PATH"
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 cd recipe
-eval `ssh-agent -s`
-ssh-add
-CARGO_NET_GIT_FETCH_WITH_CLI=true conda build .
+
+conda build .
 conda build . --output | xargs anaconda -t $ANACONDA_ORG_TOKEN upload
 

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -5,6 +5,6 @@ set -e
 export PATH="$HOME/miniconda/bin:$PATH"
 
 cd recipe
-conda build .
+CARGO_NET_GIT_FETCH_WITH_CLI=true conda build .
 conda build . --output | xargs anaconda -t $ANACONDA_ORG_TOKEN upload
 

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -5,6 +5,8 @@ set -e
 export PATH="$HOME/miniconda/bin:$PATH"
 
 cd recipe
+eval `ssh-agent -s`
+ssh-add
 CARGO_NET_GIT_FETCH_WITH_CLI=true conda build .
 conda build . --output | xargs anaconda -t $ANACONDA_ORG_TOKEN upload
 

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -5,6 +5,9 @@ set -e
 export PATH="$HOME/miniconda/bin:$PATH"
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
+echo "[url \"https://github.com/rust-lang/crates.io-index\"]" >> ~/.gitconfig
+echo "        insteadOf = https://github.com/rust-lang/crates.io-index" >> ~/.gitconfig
+
 cd recipe
 
 conda build .

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -5,6 +5,9 @@ set -e
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 export PATH="$HOME/.cargo/bin:$PATH"
 
+echo "[url \"https://github.com/rust-lang/crates.io-index\"]" >> ~/.gitconfig
+echo "        insteadOf = https://github.com/rust-lang/crates.io-index" >> ~/.gitconfig
+
 eval `ssh-agent -s`
 ssh-add
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,11 +4,11 @@ set -e
 
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 export PATH="$HOME/.cargo/bin:$PATH"
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 echo "[url \"https://github.com/rust-lang/crates.io-index\"]" >> ~/.gitconfig
 echo "        insteadOf = https://github.com/rust-lang/crates.io-index" >> ~/.gitconfig
 
-export CARGO_NET_GIT_FETCH_WITH_CLI=true
 cargo test
 
 export PATH="$HOME/miniconda/bin:$PATH"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -8,13 +8,10 @@ export PATH="$HOME/.cargo/bin:$PATH"
 echo "[url \"https://github.com/rust-lang/crates.io-index\"]" >> ~/.gitconfig
 echo "        insteadOf = https://github.com/rust-lang/crates.io-index" >> ~/.gitconfig
 
-eval `ssh-agent -s`
-ssh-add
-
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
-CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test
+cargo test
 
 export PATH="$HOME/miniconda/bin:$PATH"
 cd recipe
-CARGO_NET_GIT_FETCH_WITH_CLI=true conda build .
+conda build .
 conda build . --output

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -6,9 +6,12 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y
 export PATH="$HOME/.cargo/bin:$PATH"
 
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
-cargo test
+CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test
+
+eval `ssh-agent -s`
+ssh-add
 
 export PATH="$HOME/miniconda/bin:$PATH"
 cd recipe
-conda build .
+CARGO_NET_GIT_FETCH_WITH_CLI=true conda build .
 conda build . --output

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -5,11 +5,11 @@ set -e
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 export PATH="$HOME/.cargo/bin:$PATH"
 
-export CARGO_NET_GIT_FETCH_WITH_CLI=true
-CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test
-
 eval `ssh-agent -s`
 ssh-add
+
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test
 
 export PATH="$HOME/miniconda/bin:$PATH"
 cd recipe


### PR DESCRIPTION
Builds were flaking with ssh errors when rust's cargo tries to fetch dependencies. I don't know why builds sometimes failed and not always, but after modifying the gitconfig, builds seem to be succeeding consistently.

Error:
 ```Caused by:
  failed to authenticate when downloading repository: ssh://git@github.com/rust-lang/crates.io-index

  * attempted ssh-agent authentication, but no usernames succeeded: `git`

  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  error authenticating: no auth sock variable; class=Ssh (23)
```

The default `.gitconfig` is configured with:
```
[url "git@github.com:"]
        insteadOf = https://github.com/
```

Therefore, when rust's cargo tries to fetch 
`git clone https://github.com/rust-lang/cargo`
It will translate to
`git clone git@github.com:rust-lang/cargo`
and fail. 

Thus, we add the following to our `.gitconfig`
```
[url "https://github.com/rust-lang/crates.io-index"]
        insteadOf = https://github.com/rust-lang/crates.io-index
```

https://github.com/rust-lang/cargo/issues/8172#issuecomment-659066173
https://github.com/rust-lang/cargo/issues/8172#issuecomment-640973958