### PR TITLE
Replace conda --force flag with --yes and update miniconda version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,21 +9,21 @@ commands:
 jobs:
   unit_test_linux:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.12
     steps:
       - checkout
       - run_install_and_script 
 
   unit_test_darwin:
     macos:
-      xcode: 13.4.1
+      xcode: 16.2.0
     steps:
       - checkout
       - run_install_and_script
 
   deploy_linux:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.12
     steps:
       - checkout
       # needs ANACONDA_ORG_TOKEN env var
@@ -32,7 +32,7 @@ jobs:
 
   deploy_darwin:
     macos:
-      xcode: 13.4.1
+      xcode: 16.2.0
     steps:
       - checkout
       # needs ANACONDA_ORG_TOKEN env var

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
 jobs:
   unit_test_linux:
     docker:
-      - image: circleci/python:3.12
+      - image: cimg/python:3.12
     steps:
       - checkout
       - run_install_and_script 
@@ -23,7 +23,7 @@ jobs:
 
   deploy_linux:
     docker:
-      - image: circleci/python:3.12
+      - image: cimg/python:3.12
     steps:
       - checkout
       # needs ANACONDA_ORG_TOKEN env var

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
   unit_test_darwin:
     macos:
-      xcode: 12.5.1
+      xcode: 13.4.1
     steps:
       - checkout
       - run_install_and_script
@@ -32,7 +32,7 @@ jobs:
 
   deploy_darwin:
     macos:
-      xcode: 12.5.1
+      xcode: 13.4.1
     steps:
       - checkout
       # needs ANACONDA_ORG_TOKEN env var

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -3,10 +3,10 @@
 set -e
 
 if [[ "$(uname)" == "Darwin" ]]; then
-    URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-MacOSX-x86_64.sh"
+    URL="https://repo.anaconda.com/miniconda/Miniconda3-py39_24.11.1-0-MacOSX-arm64.sh"
     HOMEBREW_NO_AUTO_UPDATE=1 brew install wget
 else
-    URL="https://repo.anaconda.com/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh"
+    URL="https://repo.anaconda.com/miniconda/Miniconda3-py39_24.11.1-0-Linux-x86_64.sh"
 fi
 wget $URL -O miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,7 @@ fn freeze_same_platform(depfile_path: &str, lockfile_path: &str) -> Result<()> {
             &depfile_path,
             "-n",
             &tmp_name,
-            "--force",
+            "--yes",
         ],
     )?;
     info!("Made new env new env");
@@ -488,7 +488,7 @@ fn handle_create(matches: &ArgMatches) -> Result<()> {
         &[
             "env",
             "create",
-            "--force",
+            "--yes",
             "-q",
             "--json",
             "--name",


### PR DESCRIPTION
The --force flag was deprecated https://github.com/conda/conda/issues/13704 so people with newer versions of conda will get `conda: error: unrecognized arguments: --force` error when trying to create the adroit conda env.