### PR TITLE
Bump package version to 0.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-lockfile
-  version: "0.8"
+  version: "1.0"
 
 channels:
 - conda-forge

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-lockfile
-  version: "1.0"
+  version: "0.9"
 
 channels:
 - conda-forge


### PR DESCRIPTION
The last deploy failed due to existing linux version 8.0. We should re-retry the release with a new version.
<img width="989" alt="Screenshot 2025-01-09 at 12 02 27 PM" src="https://github.com/user-attachments/assets/cbe70653-629a-4624-bcc0-357bdc1f7a34" />


CI failed job: https://app.circleci.com/pipelines/github/Nextdoor/conda_lockfile/51/workflows/0de7ebff-5272-457e-9edb-74bb60003a1d/jobs/304